### PR TITLE
feat: vault_salt_sdb in template

### DIFF
--- a/clients/example.yaml
+++ b/clients/example.yaml
@@ -137,6 +137,9 @@ configuration_management:
     sentry_org_user_token: ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc1 # cat /dev/urandom | tr -dc 'a-f0-9' | fold -w 64 | head -n 1
     default_tz: Etc_UTC
     client_domain: example.com
+    #vault_salt_sdb: # optional, enable vault_salt_sdb secrets backend; both keys required when set
+    #  url: https://vault.example.com # Vault address
+    #  prefix: iac/example # per-repo KV path prefix
     heartbeat_mesh:
       sender:
         receiver: alerta1.example.com

--- a/projects.py
+++ b/projects.py
@@ -627,6 +627,8 @@ if __name__ == "__main__":
                                     VENDOR_FULL={VENDOR_FULL} \
                                     DEFAULT_TZ={DEFAULT_TZ} \
                                     CLIENT_DOMAIN={CLIENT_DOMAIN} \
+                                    VAULT_SALT_SDB_URL={VAULT_SALT_SDB_URL} \
+                                    VAULT_SALT_SDB_PREFIX={VAULT_SALT_SDB_PREFIX} \
                                     DEV_RUNNER={DEV_RUNNER} \
                                     PROD_RUNNER={PROD_RUNNER} \
                                     SALTSSH_ROOT_ED25519_PUB="{SALTSSH_ROOT_ED25519_PUB}" \
@@ -660,6 +662,8 @@ if __name__ == "__main__":
                             VENDOR_FULL=client_dict["vendor"],
                             DEFAULT_TZ=client_dict["configuration_management"]["templates"]["default_tz"],
                             CLIENT_DOMAIN=client_dict["configuration_management"]["templates"]["client_domain"],
+                            VAULT_SALT_SDB_URL=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("url", ""),
+                            VAULT_SALT_SDB_PREFIX=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("prefix", ""),
                             DEV_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["dev"] if "runners" in client_dict["gitlab"]["salt_project"] and "dev" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["dev"],
                             PROD_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["prod"] if "runners" in client_dict["gitlab"]["salt_project"] and "prod" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["prod"],
                             SALTSSH_ROOT_ED25519_PUB=client_dict["gitlab"]["salt_project"]["variables"]["SALTSSH_ROOT_ED25519_PUB"],
@@ -718,6 +722,8 @@ if __name__ == "__main__":
                                     VENDOR_FULL={VENDOR_FULL} \
                                     DEFAULT_TZ={DEFAULT_TZ} \
                                     CLIENT_DOMAIN={CLIENT_DOMAIN} \
+                                    VAULT_SALT_SDB_URL={VAULT_SALT_SDB_URL} \
+                                    VAULT_SALT_SDB_PREFIX={VAULT_SALT_SDB_PREFIX} \
                                     DEV_RUNNER={DEV_RUNNER} \
                                     SALT_MINION_VERSION={SALT_MINION_VERSION} \
                                     SALT_MASTER_VERSION={SALT_MASTER_VERSION} \
@@ -774,6 +780,8 @@ if __name__ == "__main__":
                             VENDOR_FULL=client_dict["vendor"],
                             DEFAULT_TZ=client_dict["configuration_management"]["templates"]["default_tz"],
                             CLIENT_DOMAIN=client_dict["configuration_management"]["templates"]["client_domain"],
+                            VAULT_SALT_SDB_URL=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("url", ""),
+                            VAULT_SALT_SDB_PREFIX=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("prefix", ""),
                             DEV_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["dev"] if "runners" in client_dict["gitlab"]["salt_project"] and "dev" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["dev"],
                             UFW=ufw_type
                         )


### PR DESCRIPTION
This pull request adds support for optional Vault-based Salt SDB secrets backend configuration in the client setup. The main changes involve introducing new configuration fields and updating the Python code to handle and template these values where needed.

**Configuration Management Enhancements:**

* Added commented-out example fields for `vault_salt_sdb` (`url` and `prefix`) in `clients/example.yaml` to document and enable optional Vault SDB secrets backend configuration.

**Python Code Updates:**

* Updated the `open_file` function in `projects.py` to:
  * Pass new template variables `VAULT_SALT_SDB_URL` and `VAULT_SALT_SDB_PREFIX` to relevant shell commands and templates. [[1]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R630-R631) [[2]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R725-R726)
  * Extract these values from the client configuration, defaulting to empty strings if not set, ensuring backward compatibility. [[1]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R665-R666) [[2]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R783-R784)