### PR TITLE
feat(vault): oidc jwt support for gitlab pipelines requests to vault

### DIFF
--- a/clients/example.yaml
+++ b/clients/example.yaml
@@ -137,9 +137,10 @@ configuration_management:
     sentry_org_user_token: ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc1 # cat /dev/urandom | tr -dc 'a-f0-9' | fold -w 64 | head -n 1
     default_tz: Etc_UTC
     client_domain: example.com
-    #vault_salt_sdb: # optional, enable vault_salt_sdb secrets backend; both keys required when set
+    #vault_salt_sdb: # optional, enable vault_salt_sdb secrets backend; all three keys required when set
     #  url: https://vault.example.com # Vault address
     #  prefix: iac/example # per-repo KV path prefix
+    #  jwt_role: salt-ci-example # Vault jwt auth role for CI OIDC (vault write auth/jwt/role/<this>)
     heartbeat_mesh:
       sender:
         receiver: alerta1.example.com

--- a/projects.py
+++ b/projects.py
@@ -629,6 +629,7 @@ if __name__ == "__main__":
                                     CLIENT_DOMAIN={CLIENT_DOMAIN} \
                                     VAULT_SALT_SDB_URL={VAULT_SALT_SDB_URL} \
                                     VAULT_SALT_SDB_PREFIX={VAULT_SALT_SDB_PREFIX} \
+                                    VAULT_SALT_SDB_JWT_ROLE={VAULT_SALT_SDB_JWT_ROLE} \
                                     DEV_RUNNER={DEV_RUNNER} \
                                     PROD_RUNNER={PROD_RUNNER} \
                                     SALTSSH_ROOT_ED25519_PUB="{SALTSSH_ROOT_ED25519_PUB}" \
@@ -664,6 +665,7 @@ if __name__ == "__main__":
                             CLIENT_DOMAIN=client_dict["configuration_management"]["templates"]["client_domain"],
                             VAULT_SALT_SDB_URL=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("url", ""),
                             VAULT_SALT_SDB_PREFIX=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("prefix", ""),
+                            VAULT_SALT_SDB_JWT_ROLE=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("jwt_role", ""),
                             DEV_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["dev"] if "runners" in client_dict["gitlab"]["salt_project"] and "dev" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["dev"],
                             PROD_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["prod"] if "runners" in client_dict["gitlab"]["salt_project"] and "prod" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["prod"],
                             SALTSSH_ROOT_ED25519_PUB=client_dict["gitlab"]["salt_project"]["variables"]["SALTSSH_ROOT_ED25519_PUB"],
@@ -724,6 +726,7 @@ if __name__ == "__main__":
                                     CLIENT_DOMAIN={CLIENT_DOMAIN} \
                                     VAULT_SALT_SDB_URL={VAULT_SALT_SDB_URL} \
                                     VAULT_SALT_SDB_PREFIX={VAULT_SALT_SDB_PREFIX} \
+                                    VAULT_SALT_SDB_JWT_ROLE={VAULT_SALT_SDB_JWT_ROLE} \
                                     DEV_RUNNER={DEV_RUNNER} \
                                     SALT_MINION_VERSION={SALT_MINION_VERSION} \
                                     SALT_MASTER_VERSION={SALT_MASTER_VERSION} \
@@ -782,6 +785,7 @@ if __name__ == "__main__":
                             CLIENT_DOMAIN=client_dict["configuration_management"]["templates"]["client_domain"],
                             VAULT_SALT_SDB_URL=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("url", ""),
                             VAULT_SALT_SDB_PREFIX=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("prefix", ""),
+                            VAULT_SALT_SDB_JWT_ROLE=client_dict["configuration_management"]["templates"].get("vault_salt_sdb", {}).get("jwt_role", ""),
                             DEV_RUNNER=client_dict["gitlab"]["salt_project"]["runners"]["dev"] if "runners" in client_dict["gitlab"]["salt_project"] and "dev" in client_dict["gitlab"]["salt_project"]["runners"] else acc_yaml_dict["gitlab"]["salt_project"]["runners"]["dev"],
                             UFW=ufw_type
                         )


### PR DESCRIPTION
This pull request adds support for specifying a `jwt_role` as part of the `vault_salt_sdb` configuration for clients. The changes ensure that the new `jwt_role` field is documented, properly read from configuration files, and passed through the relevant environment variables in the codebase.

Configuration updates:

* Updated the comment in `clients/example.yaml` to indicate that all three keys (`url`, `prefix`, and the new `jwt_role`) are required when enabling the `vault_salt_sdb` secrets backend, and added an example for the `jwt_role` field.

Code changes to propagate the new configuration:

* Updated `projects.py` to:
  - Add `VAULT_SALT_SDB_JWT_ROLE` as an environment variable in relevant subprocess calls and templates. [[1]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R632) [[2]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R729)
  - Read the `jwt_role` value from the client configuration and pass it as `VAULT_SALT_SDB_JWT_ROLE` when rendering templates or running commands. [[1]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R668) [[2]](diffhunk://#diff-4a11190e8da4c80e2f25e045eab979b3e524e8202e2f7ec4a0e5d6f833626377R788)